### PR TITLE
feat: add gpu manufacturer field to shadeform api

### DIFF
--- a/internal/shadeform/gen/shadeform/.openapi-generator/FILES
+++ b/internal/shadeform/gen/shadeform/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 .travis.yml
 README.md
 api/openapi.yaml
@@ -97,5 +96,4 @@ model_volume_types_inner.go
 model_volumes_response.go
 model_volumes_types_response.go
 response.go
-test/api_default_test.go
 utils.go

--- a/internal/shadeform/gen/shadeform/api/openapi.yaml
+++ b/internal/shadeform/gen/shadeform/api/openapi.yaml
@@ -514,6 +514,7 @@ components:
             vcpus: 6
             storage_in_gb: 256
             interconnect: pcie
+            gpu_manufacturer: nvidia
             os_options:
             - ubuntu22.04_cuda12.2_shade_os
             - ubuntu20.04_cuda12.0_shade_os
@@ -541,6 +542,7 @@ components:
             vcpus: 6
             storage_in_gb: 256
             interconnect: pcie
+            gpu_manufacturer: nvidia
             os_options:
             - ubuntu22.04_cuda12.2_shade_os
             - ubuntu20.04_cuda12.0_shade_os
@@ -579,6 +581,7 @@ components:
           vcpus: 6
           storage_in_gb: 256
           interconnect: pcie
+          gpu_manufacturer: nvidia
           os_options:
           - ubuntu22.04_cuda12.2_shade_os
           - ubuntu20.04_cuda12.0_shade_os
@@ -652,6 +655,7 @@ components:
             vcpus: 6
             storage_in_gb: 256
             interconnect: pcie
+            gpu_manufacturer: nvidia
           launch_configuration:
             docker_configuration:
               args: --model mistralai/Mistral-7B-v0.1
@@ -717,6 +721,7 @@ components:
             vcpus: 6
             storage_in_gb: 256
             interconnect: pcie
+            gpu_manufacturer: nvidia
           launch_configuration:
             docker_configuration:
               args: --model mistralai/Mistral-7B-v0.1
@@ -792,6 +797,7 @@ components:
           vcpus: 6
           storage_in_gb: 256
           interconnect: pcie
+          gpu_manufacturer: nvidia
         launch_configuration:
           docker_configuration:
             args: --model mistralai/Mistral-7B-v0.1
@@ -976,6 +982,7 @@ components:
           vcpus: 6
           storage_in_gb: 256
           interconnect: pcie
+          gpu_manufacturer: nvidia
         cloud_instance_type: gpu_1x_a6000
         auto_delete:
           spend_threshold: "3.14"
@@ -1198,6 +1205,7 @@ components:
         vcpus: 6
         storage_in_gb: 256
         interconnect: pcie
+        gpu_manufacturer: nvidia
         os_options:
         - ubuntu22.04_cuda12.2_shade_os
         - ubuntu20.04_cuda12.0_shade_os
@@ -1245,7 +1253,12 @@ components:
           items:
             type: string
           type: array
+        gpu_manufacturer:
+          description: The manufacturer of the gpu
+          example: nvidia
+          type: string
       required:
+      - gpu_manufacturer
       - gpu_type
       - interconnect
       - memory_in_gb
@@ -1292,7 +1305,12 @@ components:
           description: The video memory per GPU for the instance in gigabytes.
           example: 48
           type: integer
+        gpu_manufacturer:
+          description: The manufacturer of the gpu
+          example: nvidia
+          type: string
       required:
+      - gpu_manufacturer
       - gpu_type
       - interconnect
       - memory_in_gb
@@ -2693,6 +2711,7 @@ components:
         vcpus: 6
         storage_in_gb: 256
         interconnect: pcie
+        gpu_manufacturer: nvidia
     VolumeTypes_inner:
       example:
         cloud: hyperstack

--- a/internal/shadeform/gen/shadeform/docs/InstanceConfiguration.md
+++ b/internal/shadeform/gen/shadeform/docs/InstanceConfiguration.md
@@ -12,13 +12,14 @@ Name | Type | Description | Notes
 **Interconnect** | **string** | The type of GPU interconnect. | 
 **Nvlink** | Pointer to **bool** | If the instance has NVLink | [optional] 
 **VramPerGpuInGb** | **int32** | The video memory per GPU for the instance in gigabytes. | 
+**GpuManufacturer** | **string** | The manufacturer of the gpu | 
 **Os** | **string** | The operating system of the instance. | 
 
 ## Methods
 
 ### NewInstanceConfiguration
 
-`func NewInstanceConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, os string, ) *InstanceConfiguration`
+`func NewInstanceConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, gpuManufacturer string, os string, ) *InstanceConfiguration`
 
 NewInstanceConfiguration instantiates a new InstanceConfiguration object
 This constructor will assign default values to properties that have it defined,
@@ -196,6 +197,26 @@ and a boolean to check if the value has been set.
 `func (o *InstanceConfiguration) SetVramPerGpuInGb(v int32)`
 
 SetVramPerGpuInGb sets VramPerGpuInGb field to given value.
+
+
+### GetGpuManufacturer
+
+`func (o *InstanceConfiguration) GetGpuManufacturer() string`
+
+GetGpuManufacturer returns the GpuManufacturer field if non-nil, zero value otherwise.
+
+### GetGpuManufacturerOk
+
+`func (o *InstanceConfiguration) GetGpuManufacturerOk() (*string, bool)`
+
+GetGpuManufacturerOk returns a tuple with the GpuManufacturer field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetGpuManufacturer
+
+`func (o *InstanceConfiguration) SetGpuManufacturer(v string)`
+
+SetGpuManufacturer sets GpuManufacturer field to given value.
 
 
 ### GetOs

--- a/internal/shadeform/gen/shadeform/docs/InstanceTypeConfiguration.md
+++ b/internal/shadeform/gen/shadeform/docs/InstanceTypeConfiguration.md
@@ -13,12 +13,13 @@ Name | Type | Description | Notes
 **Nvlink** | Pointer to **bool** | If the instance has NVLink | [optional] 
 **VramPerGpuInGb** | **int32** | The video memory per GPU for the instance in gigabytes. | 
 **OsOptions** | **[]string** | The list of available operating systems for the instance. | 
+**GpuManufacturer** | **string** | The manufacturer of the gpu | 
 
 ## Methods
 
 ### NewInstanceTypeConfiguration
 
-`func NewInstanceTypeConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, osOptions []string, ) *InstanceTypeConfiguration`
+`func NewInstanceTypeConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, osOptions []string, gpuManufacturer string, ) *InstanceTypeConfiguration`
 
 NewInstanceTypeConfiguration instantiates a new InstanceTypeConfiguration object
 This constructor will assign default values to properties that have it defined,
@@ -216,6 +217,26 @@ and a boolean to check if the value has been set.
 `func (o *InstanceTypeConfiguration) SetOsOptions(v []string)`
 
 SetOsOptions sets OsOptions field to given value.
+
+
+### GetGpuManufacturer
+
+`func (o *InstanceTypeConfiguration) GetGpuManufacturer() string`
+
+GetGpuManufacturer returns the GpuManufacturer field if non-nil, zero value otherwise.
+
+### GetGpuManufacturerOk
+
+`func (o *InstanceTypeConfiguration) GetGpuManufacturerOk() (*string, bool)`
+
+GetGpuManufacturerOk returns a tuple with the GpuManufacturer field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetGpuManufacturer
+
+`func (o *InstanceTypeConfiguration) SetGpuManufacturer(v string)`
+
+SetGpuManufacturer sets GpuManufacturer field to given value.
 
 
 

--- a/internal/shadeform/gen/shadeform/model_instance_configuration.go
+++ b/internal/shadeform/gen/shadeform/model_instance_configuration.go
@@ -37,6 +37,8 @@ type InstanceConfiguration struct {
 	Nvlink *bool `json:"nvlink,omitempty"`
 	// The video memory per GPU for the instance in gigabytes.
 	VramPerGpuInGb int32 `json:"vram_per_gpu_in_gb"`
+	// The manufacturer of the gpu
+	GpuManufacturer string `json:"gpu_manufacturer"`
 	// The operating system of the instance.
 	Os                   string `json:"os"`
 	AdditionalProperties map[string]interface{}
@@ -48,7 +50,7 @@ type _InstanceConfiguration InstanceConfiguration
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewInstanceConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, os string) *InstanceConfiguration {
+func NewInstanceConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, gpuManufacturer string, os string) *InstanceConfiguration {
 	this := InstanceConfiguration{}
 	this.MemoryInGb = memoryInGb
 	this.StorageInGb = storageInGb
@@ -57,6 +59,7 @@ func NewInstanceConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, 
 	this.GpuType = gpuType
 	this.Interconnect = interconnect
 	this.VramPerGpuInGb = vramPerGpuInGb
+	this.GpuManufacturer = gpuManufacturer
 	this.Os = os
 	return &this
 }
@@ -269,6 +272,30 @@ func (o *InstanceConfiguration) SetVramPerGpuInGb(v int32) {
 	o.VramPerGpuInGb = v
 }
 
+// GetGpuManufacturer returns the GpuManufacturer field value
+func (o *InstanceConfiguration) GetGpuManufacturer() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.GpuManufacturer
+}
+
+// GetGpuManufacturerOk returns a tuple with the GpuManufacturer field value
+// and a boolean to check if the value has been set.
+func (o *InstanceConfiguration) GetGpuManufacturerOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.GpuManufacturer, true
+}
+
+// SetGpuManufacturer sets field value
+func (o *InstanceConfiguration) SetGpuManufacturer(v string) {
+	o.GpuManufacturer = v
+}
+
 // GetOs returns the Os field value
 func (o *InstanceConfiguration) GetOs() string {
 	if o == nil {
@@ -313,6 +340,7 @@ func (o InstanceConfiguration) ToMap() (map[string]interface{}, error) {
 		toSerialize["nvlink"] = o.Nvlink
 	}
 	toSerialize["vram_per_gpu_in_gb"] = o.VramPerGpuInGb
+	toSerialize["gpu_manufacturer"] = o.GpuManufacturer
 	toSerialize["os"] = o.Os
 
 	for key, value := range o.AdditionalProperties {
@@ -334,6 +362,7 @@ func (o *InstanceConfiguration) UnmarshalJSON(data []byte) (err error) {
 		"gpu_type",
 		"interconnect",
 		"vram_per_gpu_in_gb",
+		"gpu_manufacturer",
 		"os",
 	}
 
@@ -372,6 +401,7 @@ func (o *InstanceConfiguration) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "interconnect")
 		delete(additionalProperties, "nvlink")
 		delete(additionalProperties, "vram_per_gpu_in_gb")
+		delete(additionalProperties, "gpu_manufacturer")
 		delete(additionalProperties, "os")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/internal/shadeform/gen/shadeform/model_instance_type_configuration.go
+++ b/internal/shadeform/gen/shadeform/model_instance_type_configuration.go
@@ -38,7 +38,9 @@ type InstanceTypeConfiguration struct {
 	// The video memory per GPU for the instance in gigabytes.
 	VramPerGpuInGb int32 `json:"vram_per_gpu_in_gb"`
 	// The list of available operating systems for the instance.
-	OsOptions            []string `json:"os_options"`
+	OsOptions []string `json:"os_options"`
+	// The manufacturer of the gpu
+	GpuManufacturer      string `json:"gpu_manufacturer"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -48,7 +50,7 @@ type _InstanceTypeConfiguration InstanceTypeConfiguration
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewInstanceTypeConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, osOptions []string) *InstanceTypeConfiguration {
+func NewInstanceTypeConfiguration(memoryInGb int32, storageInGb int32, vcpus int32, numGpus int32, gpuType string, interconnect string, vramPerGpuInGb int32, osOptions []string, gpuManufacturer string) *InstanceTypeConfiguration {
 	this := InstanceTypeConfiguration{}
 	this.MemoryInGb = memoryInGb
 	this.StorageInGb = storageInGb
@@ -58,6 +60,7 @@ func NewInstanceTypeConfiguration(memoryInGb int32, storageInGb int32, vcpus int
 	this.Interconnect = interconnect
 	this.VramPerGpuInGb = vramPerGpuInGb
 	this.OsOptions = osOptions
+	this.GpuManufacturer = gpuManufacturer
 	return &this
 }
 
@@ -293,6 +296,30 @@ func (o *InstanceTypeConfiguration) SetOsOptions(v []string) {
 	o.OsOptions = v
 }
 
+// GetGpuManufacturer returns the GpuManufacturer field value
+func (o *InstanceTypeConfiguration) GetGpuManufacturer() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.GpuManufacturer
+}
+
+// GetGpuManufacturerOk returns a tuple with the GpuManufacturer field value
+// and a boolean to check if the value has been set.
+func (o *InstanceTypeConfiguration) GetGpuManufacturerOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.GpuManufacturer, true
+}
+
+// SetGpuManufacturer sets field value
+func (o *InstanceTypeConfiguration) SetGpuManufacturer(v string) {
+	o.GpuManufacturer = v
+}
+
 func (o InstanceTypeConfiguration) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -314,6 +341,7 @@ func (o InstanceTypeConfiguration) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["vram_per_gpu_in_gb"] = o.VramPerGpuInGb
 	toSerialize["os_options"] = o.OsOptions
+	toSerialize["gpu_manufacturer"] = o.GpuManufacturer
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -335,6 +363,7 @@ func (o *InstanceTypeConfiguration) UnmarshalJSON(data []byte) (err error) {
 		"interconnect",
 		"vram_per_gpu_in_gb",
 		"os_options",
+		"gpu_manufacturer",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -373,6 +402,7 @@ func (o *InstanceTypeConfiguration) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "nvlink")
 		delete(additionalProperties, "vram_per_gpu_in_gb")
 		delete(additionalProperties, "os_options")
+		delete(additionalProperties, "gpu_manufacturer")
 		o.AdditionalProperties = additionalProperties
 	}
 


### PR DESCRIPTION
Shadeform added the gpu manufacturer field which can be the following values:

1. nvidia
2. amd
3. intel
4. n/a
5. unknown

The list of possible values might grow in the future. This list may be added to in the future.