### PR TITLE
feat(BREV-1656): Add cloud to instance type

### DIFF
--- a/v1/instancetype.go
+++ b/v1/instancetype.go
@@ -45,7 +45,7 @@ type InstanceType struct {
 	NotPrivileged                   bool
 	EstimatedDeployTime             *time.Duration
 	Provider                        string
-	CloudBroker                     string
+	Cloud                           string
 	CanModifyFirewallRules          bool
 }
 
@@ -74,8 +74,8 @@ func MakeGenericInstanceTypeIDFromInstance(instance Instance) InstanceTypeID {
 type GPU struct {
 	Count          int32
 	Memory         units.Base2Bytes
-	MemoryDetails  string
-	NetworkDetails string
+	MemoryDetails  string // "", "HBM", "GDDR", "DDR", etc.
+	NetworkDetails string // "PCIe", "SXM4", "SXM5", etc.
 	Manufacturer   string
 	Name           string
 	Type           string

--- a/v1/providers/fluidstack/instancetype.go
+++ b/v1/providers/fluidstack/instancetype.go
@@ -107,5 +107,6 @@ func convertFluidStackInstanceTypeToV1InstanceType(location string, fsInstanceTy
 		IsAvailable:   isAvailable,
 		Location:      location,
 		Provider:      CloudProviderID,
+		Cloud:         CloudProviderID,
 	}
 }

--- a/v1/providers/lambdalabs/instancetype.go
+++ b/v1/providers/lambdalabs/instancetype.go
@@ -196,7 +196,8 @@ func convertLambdaLabsInstanceTypeToV1InstanceType(location string, instType ope
 		Rebootable:               true,
 		IsAvailable:              isAvailable,
 		BasePrice:                &amount,
-		Provider:                 string(CloudProviderID),
+		Provider:                 CloudProviderID,
+		Cloud:                    CloudProviderID,
 	}
 	it.ID = v1.MakeGenericInstanceTypeID(it)
 	return it, nil

--- a/v1/providers/shadeform/instancetype.go
+++ b/v1/providers/shadeform/instancetype.go
@@ -181,8 +181,8 @@ func (c *ShadeformClient) convertShadeformInstanceTypeToV1InstanceType(shadeform
 			BasePrice:   basePrice,
 			IsAvailable: region.Available,
 			Location:    region.Region,
-			Provider:    string(shadeformInstanceType.Cloud),
-			CloudBroker: CloudProviderID,
+			Provider:    CloudProviderID,
+			Cloud:       string(shadeformInstanceType.Cloud),
 		})
 	}
 


### PR DESCRIPTION
Adds the concept of "cloud" to instance types.

Cloud should be:
* the same as Provider if the Provider is its own cloud (e.g. AWS)
* the home provider of the instance if the Provider is a broker (e.g. Shadeform)