### PR TITLE
fix(nebius): add create-instance error handling for ResourceExhausted

### DIFF
--- a/v1/providers/nebius/errors.go
+++ b/v1/providers/nebius/errors.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 
+	v1 "github.com/brevdev/cloud/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/v1/providers/nebius/errors.go
+++ b/v1/providers/nebius/errors.go
@@ -32,19 +32,18 @@ func isNotFoundError(err error) bool {
 }
 
 func handleErrToCloudErr(e error) error {
-    if e == nil {
-        return nil
-    }
+	if e == nil {
+		return nil
+	}
 
-    // Check for gRPC ResourceExhausted status code
-    if grpcStatus, ok := status.FromError(e); ok {
-        if grpcStatus.Code() == codes.ResourceExhausted {
-            return v1.ErrOutOfQuota
-        }
-    }
-    return e
+	// Check for gRPC ResourceExhausted status code
+	if grpcStatus, ok := status.FromError(e); ok {
+		if grpcStatus.Code() == codes.ResourceExhausted {
+			return v1.ErrOutOfQuota
+		}
+	}
+	return e
 }
-
 
 // isAlreadyExistsError checks if an error is an "already exists" error
 //

--- a/v1/providers/nebius/errors.go
+++ b/v1/providers/nebius/errors.go
@@ -30,6 +30,21 @@ func isNotFoundError(err error) bool {
 	return false
 }
 
+func handleErrToCloudErr(e error) error {
+    if e == nil {
+        return nil
+    }
+
+    // Check for gRPC ResourceExhausted status code
+    if grpcStatus, ok := status.FromError(e); ok {
+        if grpcStatus.Code() == codes.ResourceExhausted {
+            return v1.ErrOutOfQuota
+        }
+    }
+    return e
+}
+
+
 // isAlreadyExistsError checks if an error is an "already exists" error
 //
 //nolint:unused // Reserved for future error handling improvements

--- a/v1/providers/nebius/instance.go
+++ b/v1/providers/nebius/instance.go
@@ -143,17 +143,18 @@ func (c *NebiusClient) CreateInstance(ctx context.Context, attrs v1.CreateInstan
 
 	operation, err := c.sdk.Services().Compute().V1().Instance().Create(ctx, createReq)
 	if err != nil {
-		return nil, errors.WrapAndTrace(err)
+		return nil, errors.WrapAndTrace(handleErrToCloudErr(err))
 	}
 
 	// Wait for the operation to complete and get the actual instance ID
 	finalOp, err := operation.Wait(ctx)
 	if err != nil {
-		return nil, errors.WrapAndTrace(err)
+		return nil, errors.WrapAndTrace(handleErrToCloudErr(err))
 	}
 
 	if !finalOp.Successful() {
-		return nil, fmt.Errorf("instance creation failed: %v", finalOp.Status())
+        statusErr := fmt.Errorf("instance creation failed: %v", finalOp.Status())
+        return nil, handleErrToCloudErr(statusErr)
 	}
 
 	// Get the actual instance ID from the completed operation

--- a/v1/providers/nebius/instance.go
+++ b/v1/providers/nebius/instance.go
@@ -153,8 +153,8 @@ func (c *NebiusClient) CreateInstance(ctx context.Context, attrs v1.CreateInstan
 	}
 
 	if !finalOp.Successful() {
-        statusErr := fmt.Errorf("instance creation failed: %v", finalOp.Status())
-        return nil, handleErrToCloudErr(statusErr)
+		statusErr := fmt.Errorf("instance creation failed: %v", finalOp.Status())
+		return nil, handleErrToCloudErr(statusErr)
 	}
 
 	// Get the actual instance ID from the completed operation


### PR DESCRIPTION
**Summary**
Map gRPC ResourceExhausted errors to ErrOutOfQuota during instance creation to ensure quota failures return a consistent cloud error.

**Root Cause**
Quota-related failures from the provider surfaced as raw gRPC errors, resulting in inconsistent error handling and unclear feedback when instance creation exceeded available resources.

**Changes**
Add handleErrToCloudErr() to translate ResourceExhausted into ErrOutOfQuota
Apply the handler to create-instance request, operation wait, and unsuccessful operation states
Improve reliability and clarity of quota error reporting