### PR TITLE
fix: handle provider status default cases across providers.

### DIFF
--- a/v1/instance.go
+++ b/v1/instance.go
@@ -112,7 +112,7 @@ const (
 	LifecycleStatusTerminating LifecycleStatus = "terminating"
 	LifecycleStatusTerminated  LifecycleStatus = "terminated"
 	LifecycleStatusFailed      LifecycleStatus = "failed"
-	LifecycleStatusEmpty	   LifecycleStatus = ""
+	LifecycleStatusEmpty       LifecycleStatus = ""
 )
 
 const (

--- a/v1/instance.go
+++ b/v1/instance.go
@@ -112,6 +112,7 @@ const (
 	LifecycleStatusTerminating LifecycleStatus = "terminating"
 	LifecycleStatusTerminated  LifecycleStatus = "terminated"
 	LifecycleStatusFailed      LifecycleStatus = "failed"
+	LifecycleStatusEmpty	   LifecycleStatus = ""
 )
 
 const (

--- a/v1/providers/fluidstack/instance.go
+++ b/v1/providers/fluidstack/instance.go
@@ -131,7 +131,7 @@ func convertFluidStackInstanceToV1Instance(fsInstance openapi.Instance) *v1.Inst
 	case openapi.INSTANCE_ERROR:
 		lifecycleStatus = v1.LifecycleStatusFailed
 	default:
-		lifecycleStatus = v1.LifecycleStatusPending
+		lifecycleStatus = ""
 	}
 
 	instance := &v1.Instance{

--- a/v1/providers/fluidstack/instance.go
+++ b/v1/providers/fluidstack/instance.go
@@ -131,7 +131,7 @@ func convertFluidStackInstanceToV1Instance(fsInstance openapi.Instance) *v1.Inst
 	case openapi.INSTANCE_ERROR:
 		lifecycleStatus = v1.LifecycleStatusFailed
 	default:
-		lifecycleStatus = ""
+		lifecycleStatus = v1.LifecycleStatusEmpty
 	}
 
 	instance := &v1.Instance{

--- a/v1/providers/lambdalabs/instance.go
+++ b/v1/providers/lambdalabs/instance.go
@@ -217,7 +217,7 @@ func convertLambdaLabsStatusToV1Status(status string) v1.LifecycleStatus {
 	case "unhealthy":
 		return v1.LifecycleStatusRunning
 	default:
-		return v1.LifecycleStatusPending
+		return ""
 	}
 }
 

--- a/v1/providers/lambdalabs/instance.go
+++ b/v1/providers/lambdalabs/instance.go
@@ -217,7 +217,7 @@ func convertLambdaLabsStatusToV1Status(status string) v1.LifecycleStatus {
 	case "unhealthy":
 		return v1.LifecycleStatusRunning
 	default:
-		return ""
+		return v1.LifecycleStatusEmpty
 	}
 }
 

--- a/v1/providers/nebius/instance.go
+++ b/v1/providers/nebius/instance.go
@@ -247,7 +247,7 @@ func (c *NebiusClient) convertNebiusInstanceToV1(ctx context.Context, instance *
 		case compute.InstanceStatus_ERROR:
 			lifecycleStatus = v1.LifecycleStatusFailed
 		default:
-			lifecycleStatus = ""
+			lifecycleStatus = v1.LifecycleStatusEmpty
 		}
 	} else {
 		lifecycleStatus = v1.LifecycleStatusFailed

--- a/v1/providers/nebius/instance.go
+++ b/v1/providers/nebius/instance.go
@@ -247,7 +247,7 @@ func (c *NebiusClient) convertNebiusInstanceToV1(ctx context.Context, instance *
 		case compute.InstanceStatus_ERROR:
 			lifecycleStatus = v1.LifecycleStatusFailed
 		default:
-			lifecycleStatus = v1.LifecycleStatusFailed
+			lifecycleStatus = ""
 		}
 	} else {
 		lifecycleStatus = v1.LifecycleStatusFailed

--- a/v1/providers/sfcompute/instance.go
+++ b/v1/providers/sfcompute/instance.go
@@ -415,7 +415,7 @@ func sfcStatusToLifecycleStatus(status string) v1.LifecycleStatus {
 	case "nodefailure", "failed":
 		return v1.LifecycleStatusFailed
 	default:
-		return ""
+		return v1.LifecycleStatusEmpty
 	}
 }
 

--- a/v1/providers/sfcompute/instance.go
+++ b/v1/providers/sfcompute/instance.go
@@ -415,7 +415,7 @@ func sfcStatusToLifecycleStatus(status string) v1.LifecycleStatus {
 	case "nodefailure", "failed":
 		return v1.LifecycleStatusFailed
 	default:
-		return v1.LifecycleStatusPending
+		return ""
 	}
 }
 

--- a/v1/providers/shadeform/instance.go
+++ b/v1/providers/shadeform/instance.go
@@ -291,7 +291,7 @@ func (c *ShadeformClient) getLifecycleStatus(status string) v1.LifecycleStatus {
 	case "error":
 		lifecycleStatus = v1.LifecycleStatusFailed
 	default:
-		lifecycleStatus = v1.LifecycleStatusPending
+		lifecycleStatus = ""
 	}
 	return lifecycleStatus
 }

--- a/v1/providers/shadeform/instance.go
+++ b/v1/providers/shadeform/instance.go
@@ -291,7 +291,7 @@ func (c *ShadeformClient) getLifecycleStatus(status string) v1.LifecycleStatus {
 	case "error":
 		lifecycleStatus = v1.LifecycleStatusFailed
 	default:
-		lifecycleStatus = ""
+		lifecycleStatus = v1.LifecycleStatusEmpty
 	}
 	return lifecycleStatus
 }


### PR DESCRIPTION
#### Problem
Across several providers, unknown/transient status values were being coerced into concrete lifecycle states (commonly `pending`). During deletion this led to incorrect “Starting/Deploying” signals and contributed to UI status regressions.

#### Root cause
Default-case handling in provider status mappers treated unknown values as known states instead of surfacing “unknown.”

#### Fix
- Standardize provider mappers to return “unknown” (empty/unset lifecycle) for unrecognized provider status values, rather than defaulting to `pending`/`failed`.