### PR TITLE
fix: nebius provisioning error

### DIFF
--- a/v1/providers/nebius/errors.go
+++ b/v1/providers/nebius/errors.go
@@ -1,9 +1,11 @@
 package v1
 
 import (
+	"errors"
 	"fmt"
 
 	v1 "github.com/brevdev/cloud/v1"
+	"github.com/nebius/gosdk/operations"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -35,7 +37,13 @@ func handleErrToCloudErr(e error) error {
 	if e == nil {
 		return nil
 	}
-
+	// Check for Nebius operations.Error for ResourceExhausted (returned by operation.Wait on async failures)
+	var opErr *operations.Error
+	if errors.As(e, &opErr) {
+		if opErr.Code == codes.ResourceExhausted {
+			return v1.ErrOutOfQuota
+		}
+	}
 	// Check for gRPC ResourceExhausted status code
 	if grpcStatus, ok := status.FromError(e); ok {
 		if grpcStatus.Code() == codes.ResourceExhausted {


### PR DESCRIPTION
**Problem**
Nebius instance provisioning failures caused by quota or capacity exhaustion were not being surfaced as a recognizable error. The SDK returns an `*operations.Error` that the existing gRPC status check cannot unwrap. As a result, ErrOutOfQuota was never returned, and the failure bubbled up as an raw Nebius error. 

**Solution**
Added a pre-check in handleErrToCloudErr using `errors.As` to specifically match `*operations.Error` before falling through to the gRPC status check.