### PR TITLE
fix(sfcompute-v2): update sfc-go, adopt capacities -> pools rename

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brevdev/cloud
 
-go 1.25.1
+go 1.25.10
 
 require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
@@ -22,7 +22,7 @@ require (
 	github.com/nebius/gosdk v0.0.0-20250826102719-940ad1dfb5de
 	github.com/pkg/errors v0.9.1
 	github.com/sfcompute/nodes-go v0.1.0-alpha.4
-	github.com/sfcompute/sfc-go v0.1.0-preview.2
+	github.com/sfcompute/sfc-go v0.1.0-preview.2.0.20260626173751-becf3866cc44
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/text v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nebius/gosdk v0.0.0-20250826102719-940ad1dfb5de
 	github.com/pkg/errors v0.9.1
 	github.com/sfcompute/nodes-go v0.1.0-alpha.4
-	github.com/sfcompute/sfc-go v0.1.0-preview.2.0.20260626173751-becf3866cc44
+	github.com/sfcompute/sfc-go v0.1.0-preview.3
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sfcompute/nodes-go v0.1.0-alpha.4 h1:oFBWcMPSpqLYm/NDs5I1jTvzgx9rsXDL9Ghsm30Hc0Q=
 github.com/sfcompute/nodes-go v0.1.0-alpha.4/go.mod h1:nUviHgK+Fgt2hDFcRL3M8VoyiypC8fc0dsY8C30QU8M=
-github.com/sfcompute/sfc-go v0.1.0-preview.2 h1:IzLovv15bnfh+nwgPK1/rKidCNome9rq06j0vnrzKf0=
-github.com/sfcompute/sfc-go v0.1.0-preview.2/go.mod h1:vhUpRpAHKitZzzWPg87RjreC+pzK57PGe4ZuSIQSk94=
+github.com/sfcompute/sfc-go v0.1.0-preview.2.0.20260626173751-becf3866cc44 h1:V3OcrL4ImkDj3ymnSGJC/iOW/mAMvyp59KCqZZabOdw=
+github.com/sfcompute/sfc-go v0.1.0-preview.2.0.20260626173751-becf3866cc44/go.mod h1:SDgYqB2R6gFM+bzLBeF/Fb+J1HHaTlDuStSkiFuMWDU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sfcompute/nodes-go v0.1.0-alpha.4 h1:oFBWcMPSpqLYm/NDs5I1jTvzgx9rsXDL9Ghsm30Hc0Q=
 github.com/sfcompute/nodes-go v0.1.0-alpha.4/go.mod h1:nUviHgK+Fgt2hDFcRL3M8VoyiypC8fc0dsY8C30QU8M=
-github.com/sfcompute/sfc-go v0.1.0-preview.2.0.20260626173751-becf3866cc44 h1:V3OcrL4ImkDj3ymnSGJC/iOW/mAMvyp59KCqZZabOdw=
-github.com/sfcompute/sfc-go v0.1.0-preview.2.0.20260626173751-becf3866cc44/go.mod h1:SDgYqB2R6gFM+bzLBeF/Fb+J1HHaTlDuStSkiFuMWDU=
+github.com/sfcompute/sfc-go v0.1.0-preview.3 h1:azKThmbm9ljQ+z8RP4039XwV4bJMTcYKNpKcxrpNf5A=
+github.com/sfcompute/sfc-go v0.1.0-preview.3/go.mod h1:SDgYqB2R6gFM+bzLBeF/Fb+J1HHaTlDuStSkiFuMWDU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/v1/providers/sfcomputev2/brev_constants.go
+++ b/v1/providers/sfcomputev2/brev_constants.go
@@ -15,8 +15,8 @@ const (
 	brevDefaultImageResourcePath = "sfc:image:sfcompute:public:ubuntu-24.04.4-cuda-12.8"
 )
 
-func (c *SFCClientV2) GetDefaultCapacityResourcePath() string {
-	return fmt.Sprintf("sfc:capacity:%s:%s:default", c.organization, c.workspace)
+func (c *SFCClientV2) GetDefaultPoolResourcePath() string {
+	return fmt.Sprintf("sfc:pool:%s:%s:default", c.organization, c.workspace)
 }
 
 func (c *SFCClientV2) GetWorkspaceResourcePath() string {

--- a/v1/providers/sfcomputev2/instance.go
+++ b/v1/providers/sfcomputev2/instance.go
@@ -57,7 +57,7 @@ func (c *SFCClientV2) CreateInstance(ctx context.Context, attrs v1.CreateInstanc
 
 	cloudInit := sshKeyCloudInit(attrs.PublicKey)
 	req := components.CreateInstanceRequest{
-		Capacity:          c.GetDefaultCapacityResourcePath(),
+		Pool:              c.GetDefaultCapacityResourcePath(),
 		Image:             c.GetDefaultImageResourcePath(),
 		InstanceSku:       sku,
 		CloudInitUserData: &cloudInit,
@@ -133,7 +133,7 @@ func (c *SFCClientV2) ListInstances(ctx context.Context, args v1.ListInstancesAr
 	capacityID := c.GetDefaultCapacityResourcePath()
 	resp, err := c.client.Instances.List(ctx, operations.ListInstancesRequest{
 		Workspace: c.GetWorkspaceResourcePath(),
-		Capacity:  &capacityID,
+		Pool:      []string{capacityID},
 	})
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)

--- a/v1/providers/sfcomputev2/instance.go
+++ b/v1/providers/sfcomputev2/instance.go
@@ -57,7 +57,7 @@ func (c *SFCClientV2) CreateInstance(ctx context.Context, attrs v1.CreateInstanc
 
 	cloudInit := sshKeyCloudInit(attrs.PublicKey)
 	req := components.CreateInstanceRequest{
-		Pool:              c.GetDefaultCapacityResourcePath(),
+		Pool:              c.GetDefaultPoolResourcePath(),
 		Image:             c.GetDefaultImageResourcePath(),
 		InstanceSku:       sku,
 		CloudInitUserData: &cloudInit,
@@ -130,10 +130,10 @@ func (c *SFCClientV2) ListInstances(ctx context.Context, args v1.ListInstancesAr
 		v1.LogField("location", c.location),
 	)
 
-	capacityID := c.GetDefaultCapacityResourcePath()
+	poolID := c.GetDefaultPoolResourcePath()
 	resp, err := c.client.Instances.List(ctx, operations.ListInstancesRequest{
 		Workspace: c.GetWorkspaceResourcePath(),
-		Pool:      []string{capacityID},
+		Pool:      []string{poolID},
 	})
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)

--- a/v1/providers/sfcomputev2/instancetype.go
+++ b/v1/providers/sfcomputev2/instancetype.go
@@ -140,23 +140,23 @@ func (c *SFCClientV2) GetInstanceTypes(ctx context.Context, args v1.GetInstanceT
 func (c *SFCClientV2) skuFreeCapacity(ctx context.Context) (map[string]int, error) {
 	capacityID := c.GetDefaultCapacityResourcePath()
 
-	capResp, err := c.client.Capacities.Fetch(ctx, capacityID, nil)
+	capResp, err := c.client.Pools.Fetch(ctx, capacityID, nil)
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)
 	}
-	if capResp.CapacityResponse == nil {
+	if capResp.PoolResponse == nil {
 		return map[string]int{}, nil
 	}
 
 	now := time.Now().Unix()
 	free := make(map[string]int)
-	for skuID, schedule := range capResp.CapacityResponse.AllocationSchedule.ByInstanceSku {
+	for skuID, schedule := range capResp.PoolResponse.AllocationSchedule.ByInstanceSku {
 		free[skuID] = currentScheduleAllocation(schedule, now)
 	}
 
 	resp, err := c.client.Instances.List(ctx, operations.ListInstancesRequest{
 		Workspace: c.GetWorkspaceResourcePath(),
-		Capacity:  &capacityID,
+		Pool:      []string{capacityID},
 	})
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)

--- a/v1/providers/sfcomputev2/instancetype.go
+++ b/v1/providers/sfcomputev2/instancetype.go
@@ -138,25 +138,25 @@ func (c *SFCClientV2) GetInstanceTypes(ctx context.Context, args v1.GetInstanceT
 // per-SKU allocation from the capacity schedule and the per-SKU consumption from the instance
 // list, issuing exactly two API calls.
 func (c *SFCClientV2) skuFreeCapacity(ctx context.Context) (map[string]int, error) {
-	capacityID := c.GetDefaultCapacityResourcePath()
+	poolID := c.GetDefaultPoolResourcePath()
 
-	capResp, err := c.client.Pools.Fetch(ctx, capacityID, nil)
+	poolResp, err := c.client.Pools.Fetch(ctx, poolID, nil)
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)
 	}
-	if capResp.PoolResponse == nil {
+	if poolResp.PoolResponse == nil {
 		return map[string]int{}, nil
 	}
 
 	now := time.Now().Unix()
 	free := make(map[string]int)
-	for skuID, schedule := range capResp.PoolResponse.AllocationSchedule.ByInstanceSku {
+	for skuID, schedule := range poolResp.PoolResponse.AllocationSchedule.ByInstanceSku {
 		free[skuID] = currentScheduleAllocation(schedule, now)
 	}
 
 	resp, err := c.client.Instances.List(ctx, operations.ListInstancesRequest{
 		Workspace: c.GetWorkspaceResourcePath(),
-		Pool:      []string{capacityID},
+		Pool:      []string{poolID},
 	})
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)
@@ -233,7 +233,7 @@ func (c *SFCClientV2) selectAvailableSku(ctx context.Context) (string, error) {
 			return skuID, nil
 		}
 	}
-	return "", fmt.Errorf("no instance SKU with available capacity in %s", c.GetDefaultCapacityResourcePath())
+	return "", fmt.Errorf("no instance SKU with available capacity in %s", c.GetDefaultPoolResourcePath())
 }
 
 func (c *SFCClientV2) GetLocations(_ context.Context, _ v1.GetLocationsArgs) ([]v1.Location, error) {


### PR DESCRIPTION
This PR makes two updates to the sfcompute-v2 provider, which is built against our preview v2 API:
1. We made some breaking schema changes to fields that brev doesn't use, but sfc-go would fail deserializing. We separately pushed an update to sfc-go - this PR updates to the new version.
2. We renamed Capacities to Pools. While this is not breaking (we still support the old name), we can take the opportunity here to adopt the new naming.