### PR TITLE
fix: reduce LaunchPad list deployments page size

### DIFF
--- a/v1/providers/launchpad/instance_list.go
+++ b/v1/providers/launchpad/instance_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (c *LaunchpadClient) ListInstances(ctx context.Context, args v1.ListInstancesArgs) ([]v1.Instance, error) {
-	deployments, err := c.paginateListDeployments(ctx, 1000)
+	deployments, err := c.paginateListDeployments(ctx, 500)
 	if err != nil {
 		return nil, errors.WrapAndTrace(err)
 	}


### PR DESCRIPTION
The LaunchPad API will be adding a max page size of 500 for all endpoints. This change reduces the LaunchPad client's `paginateListDeployments` call to match that.

This won't really have an impact today because Brev's LP deployment list is ~180 items. This is just intended to keep things inline with the maximum allowed size to avoid any future surprises.