### PR TITLE
fix: add Launchpad DMZ GH200 experience

### DIFF
--- a/v1/providers/launchpad/instance_create.go
+++ b/v1/providers/launchpad/instance_create.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"net"
+	"strings"
 
 	"github.com/brevdev/cloud/internal/collections"
 	"github.com/brevdev/cloud/internal/errors"
@@ -13,8 +14,9 @@ import (
 )
 
 const (
-	brevExperienceID    = "43123766-35ec-4eb4-a5ba-3f2945228445"
-	minimalExperienceID = "a5d93f56-bbdb-44db-a1ae-6b1ad7d3c6df"
+	brevExperienceID      = "43123766-35ec-4eb4-a5ba-3f2945228445"
+	minimalExperienceID   = "a5d93f56-bbdb-44db-a1ae-6b1ad7d3c6df"
+	brevGH200ExperienceID = "d12c37eb-270a-4471-be45-48e4d1fdb764"
 )
 
 func (c *LaunchpadClient) CreateInstance(ctx context.Context, attrs v1.CreateInstanceAttrs) (*v1.Instance, error) {
@@ -99,7 +101,16 @@ func instanceTypeToLaunchpadExperience(instanceTypeInfo instanceTypeInfo) string
 	if instanceTypeInfo.cloud == "nebius" {
 		return minimalExperienceID
 	}
+	if matchesGH200Experience(instanceTypeInfo) {
+		return brevGH200ExperienceID
+	}
 	return brevExperienceID
+}
+
+func matchesGH200Experience(info instanceTypeInfo) bool {
+	return info.cloud == dmzCloud &&
+		strings.EqualFold(info.gpuName, "gh200") &&
+		strings.EqualFold(info.gpuNetworkDetails, "sxm")
 }
 
 type launchpadCreateAttrs v1.CreateInstanceAttrs

--- a/v1/providers/launchpad/instance_create_test.go
+++ b/v1/providers/launchpad/instance_create_test.go
@@ -35,3 +35,51 @@ func TestLaunchpadClient_CreateInstance(t *testing.T) {
 
 	t.Logf("instance: %v", instance)
 }
+
+func Test_instanceTypeToLaunchpadExperience(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		info     instanceTypeInfo
+		expected string
+	}{
+		{
+			name:     "nebius uses the minimal experience",
+			info:     instanceTypeInfo{cloud: "nebius"},
+			expected: minimalExperienceID,
+		},
+		{
+			name:     "gh200 SXM uses the gh200 experience",
+			info:     instanceTypeInfo{cloud: dmzCloud, gpuName: "gh200", gpuNetworkDetails: "sxm", gpuCount: 1},
+			expected: brevGH200ExperienceID,
+		},
+		{
+			name:     "gh200 SXM selection is count-agnostic",
+			info:     instanceTypeInfo{cloud: dmzCloud, gpuName: "gh200", gpuNetworkDetails: "sxm", gpuCount: 8},
+			expected: brevGH200ExperienceID,
+		},
+		{
+			name:     "gh200 PCIe does not match the SXM-only gh200 experience",
+			info:     instanceTypeInfo{cloud: dmzCloud, gpuName: "gh200", gpuNetworkDetails: "pcie", gpuCount: 1},
+			expected: brevExperienceID,
+		},
+		{
+			name:     "non-gh200 GPU on SXM uses the default experience",
+			info:     instanceTypeInfo{cloud: dmzCloud, gpuName: "h100", gpuNetworkDetails: "sxm", gpuCount: 1},
+			expected: brevExperienceID,
+		},
+		{
+			name:     "gh200 SXM on a non-dmz cloud uses the default experience",
+			info:     instanceTypeInfo{cloud: "oci", gpuName: "gh200", gpuNetworkDetails: "sxm", gpuCount: 1},
+			expected: brevExperienceID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, instanceTypeToLaunchpadExperience(tt.info))
+		})
+	}
+}


### PR DESCRIPTION
Fixes InsufficientCapacity failures when launching dmz.gh200x1.sxm on Launchpad. GH200 instances were failing even when GH200 capacity was available, because Brev requested the default amd64 Brev experience for arm64 GH200 hardware. Launchpad matches capacity against the experience's system_arch, found no amd64 GH200 nodes, and returned InsufficientCapacity despite ready arm64 GH200 capacity.

This change routes DMZ GH200 SXM instance types to the dedicated arm64 GH200 Launchpad experience.