### PR TITLE
fix: Calculate Verda GPU VRAM as Per GPU

### DIFF
--- a/v1/providers/verda/client_test.go
+++ b/v1/providers/verda/client_test.go
@@ -56,6 +56,27 @@ func TestWrapVerdaInsufficientResourcesError(t *testing.T) {
 	assert.False(t, errors.Is(err, v1.ErrServiceUnavailable))
 }
 
+func TestVerdaInstanceTypeUsesPerGPUMemory(t *testing.T) {
+	instanceType, err := verdaInstanceTypeToInstanceType(verdago.InstanceTypeInfo{
+		InstanceType: "8V100.128G",
+		Model:        "V100 16GB",
+		GPU: verdago.InstanceGPU{
+			NumberOfGPUs: 8,
+		},
+		GPUMemory: verdago.InstanceMemory{
+			SizeInGigabytes: 128,
+		},
+		PricePerHour: 1,
+		Currency:     "usd",
+	}, "FIN-01")
+	require.NoError(t, err)
+	require.Len(t, instanceType.SupportedGPUs, 1)
+
+	gpu := instanceType.SupportedGPUs[0]
+	assert.Equal(t, int32(8), gpu.Count)
+	assert.Equal(t, v1.NewBytes(16, v1.Gigabyte), gpu.MemoryBytes)
+}
+
 func TestGetInstanceTypesAndLocations(t *testing.T) { //nolint:funlen // One catalog fixture exercises all shared validations.
 	server := newVerdaTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/v1/providers/verda/instancetype.go
+++ b/v1/providers/verda/instancetype.go
@@ -94,7 +94,9 @@ func verdaInstanceTypeToInstanceType(verdaType verdago.InstanceTypeInfo, locatio
 	}
 
 	if verdaType.GPU.NumberOfGPUs > 0 {
-		gpuMemory, gpuMemoryBytes := byteSizes(int64(verdaType.GPUMemory.SizeInGigabytes), v1.Gigabyte)
+		// The Verda API does not expose the GPU memory per GPU, so we need to calculate it
+		gpuMemoryGB := int64(verdaType.GPUMemory.SizeInGigabytes) / int64(verdaType.GPU.NumberOfGPUs)
+		gpuMemory, gpuMemoryBytes := byteSizes(gpuMemoryGB, v1.Gigabyte)
 		gpuModel := strings.ToUpper(strings.TrimSpace(verdaType.Model))
 		instanceType.SupportedGPUs = []v1.GPU{{
 			Count:          int32(verdaType.GPU.NumberOfGPUs), //nolint:gosec // ok


### PR DESCRIPTION
Verda multiples GPU*VRAM in their final field. We expect true per-GPU VRAM, so we need to divide VRAM by GPU count.