### PR TITLE
fix(sfcompute): stop sending deprecated InfiniBand field

### DIFF
--- a/v1/providers/sfcomputev2/api_client.go
+++ b/v1/providers/sfcomputev2/api_client.go
@@ -24,13 +24,12 @@ type apiClient struct {
 }
 
 type createInstanceRequest struct {
-	Name                    *string           `json:"name,omitempty"`
-	Pool                    string            `json:"pool"`
-	Image                   string            `json:"image"`
-	InstanceSKU             string            `json:"instance_sku"`
-	CloudInitUserData       *string           `json:"cloud_init_user_data,omitempty"`
-	Tags                    map[string]string `json:"tags,omitempty"`
-	PreviewEnableInfiniband bool              `json:"_preview_enable_infiniband"`
+	Name              *string           `json:"name,omitempty"`
+	Pool              string            `json:"pool"`
+	Image             string            `json:"image"`
+	InstanceSKU       string            `json:"instance_sku"`
+	CloudInitUserData *string           `json:"cloud_init_user_data,omitempty"`
+	Tags              map[string]string `json:"tags,omitempty"`
 }
 
 type instanceStatus string

--- a/v1/providers/sfcomputev2/api_client_test.go
+++ b/v1/providers/sfcomputev2/api_client_test.go
@@ -27,7 +27,7 @@ func TestAPIClientUsesBrevContract(t *testing.T) {
 			tags, ok := body["tags"].(map[string]any)
 			require.True(t, ok)
 			require.Equal(t, "brev-ref", tags[tagKeyRefID])
-			require.Equal(t, false, body["_preview_enable_infiniband"])
+			require.NotContains(t, body, "_preview_enable_infiniband")
 			writeJSON(t, writer, instanceResponse{ID: "inst_created", Status: instanceStatusAwaitingAllocation})
 		case "GET /integrations/brev/v1/instances":
 			require.Equal(t, "sfc:workspace:account:workspace", request.URL.Query().Get("workspace"))


### PR DESCRIPTION
## Context

SF Compute now derives InfiniBand passthrough from the authenticated account's effective SKU configuration. The legacy request field is deprecated and ignored, and keeping this client-side writer would leave Brev sending obsolete policy input on every instance create.

## Changes

- Remove the legacy `_preview_enable_infiniband` field from the SF Compute request body.
- Assert that the Brev contract no longer emits the field.

This is rollout-safe with current and new SF Compute servers: omission already defaults to false, and the compatibility API continues accepting older clients that still send the field.

## Testing

- `make vet fmt-check test`
- `go test ./v1/providers/sfcomputev2`
